### PR TITLE
Submodule 관리를 위해 fork repo를 만들고 branch로 연결

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "external/glfw"]
 	path = external/glfw
-	url = git@github.com:glfw/glfw.git
+	url = git@github.com:habijung/glfw.git
+	branch = learn-opengl
 [submodule "external/glm"]
 	path = external/glm
-	url = git@github.com:g-truc/glm.git
+	url = git@github.com:habijung/glm.git
+	branch = learn-opengl
 [submodule "external/assimp"]
 	path = external/assimp
-	url = git@github.com:assimp/assimp.git
+	url = git@github.com:habijung/assimp.git
+	branch = learn-opengl

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 [Learn OpenGL](https://learnopengl.com/) 사이트에서 보고, 듣고, 느끼고, 배우는 것들을 기록
 
 
+# Recent Result
+
+[Model Loading ▶️ ASSIMP, Mesh, Model #2](https://github.com/habijung/learn-opengl/pull/2)
+
+
 # Prerequisite
 
 | Library | Version |
@@ -10,31 +15,22 @@
 | GLAD    |     3.3 |
 | GLFW    |   3.3.8 |
 | GLM     | 0.9.9.8 |
+| ASSIMP  |   5.2.5 | 
 
 
 # Build
 
-JesBrains의 CLion에서 빌드
+JesBrains의 CLion에서 실행함
 
 - Clone OpenGL project
 ```commandline
 $ git clone git@github.com:habijung/learn-opengl.git
-$ git submodule update --init --recursive
+$ git submodule update --init --recursive --remote
 ```
-
-- Update Libraries Tag
-```commandline
-# GLFW
-$ cd external/glfw
-$ git checkout tags/3.3.8
-
-# GLM
-$ cd external/glm
-$ git checkout tags/0.9.9.8
-
-# ASSIMP
-# 추가 예정
-```
-
 - CLion에서 프로젝트 폴더 열기
+- Build CMake
 - Run Project
+
+
+---
+**Updated:** 2023.01.15 04:00


### PR DESCRIPTION
## 개요

프로젝트에 사용되는 submodule이 OS에 따라 차이가 발생함.
그래서 submodule의 원하는 commit에서 직접 branch를 생성하고, 관리하기 위해서 `Fork` 저장소를 따로 생성함.


## 진행 상황

- GLFW, GLM, ASSIMP의 Fork 저장소 생성
- 각 저장소에서 `master` branch와 `v` tag를 제외한 나머지를 삭제
- 필요한 commit에서 `learn-opengl` branch 생성하고 `push`
- Submodule을 업데이트